### PR TITLE
remove java dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ WASM_OPTIONS = \
 	--llvm-lto 3 \
 	--llvm-opts 3 \
 	--js-opts 1 \
-	--closure 1 \
+	--closure 0 \
 	-s ENVIRONMENT=web \
 	-s MODULARIZE=1 \
 	-s ALLOW_MEMORY_GROWTH=1 \
@@ -51,7 +51,7 @@ ASMJS_OPTIONS = \
 	--llvm-lto 3 \
 	--llvm-opts 3 \
 	--js-opts 1 \
-	--closure 1 \
+	--closure 0 \
 	-s ENVIRONMENT=web \
 	-s MODULARIZE=1 \
 	-s AGGRESSIVE_VARIABLE_ELIMINATION=1 \

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ The boilerplate automatically compiles C++ code to WebAssembly and asm.js, the c
 - [npm](http://npmjs.com/)
 - [make](https://www.gnu.org/software/make/)
 - [emcc](http://webassembly.org/getting-started/developers-guide/)
-- [java](https://www.java.com)
 
 Please make sure to have `emcc` set as an environment variable and the lastest version of `node` to make parcel work. So, to validate the installation, please run the following commands:
 
@@ -25,7 +24,6 @@ node -v
 npm -v
 make -v
 emcc -v
-java -version
 ```
 
 ## Getting started


### PR DESCRIPTION
the ability to compile clojure is optional in emscripten and we don't need it for asm-dom-boilerplate. those of us who have managed not to install java will be happy not to install it.