### PR TITLE
fixed issue 12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ WASM_OPTIONS = \
 	--llvm-lto 3 \
 	--llvm-opts 3 \
 	--js-opts 1 \
-	--closure 1 \
+	--closure 0 \
 	-s ENVIRONMENT=web \
 	-s MODULARIZE=1 \
 	-s ALLOW_MEMORY_GROWTH=1 \
@@ -41,7 +41,7 @@ WASM_OPTIONS = \
 	-s DISABLE_EXCEPTION_CATCHING=2 \
 	-s BINARYEN=1 \
 	-s EXPORTED_RUNTIME_METHODS=[\'UTF8ToString\'] \
-	-s BINARYEN_TRAP_MODE=\'allow\'
+	# -s BINARYEN_TRAP_MODE=\'allow\'
 
 # C++ => .asm.js options
 ASMJS_OPTIONS = \
@@ -51,7 +51,7 @@ ASMJS_OPTIONS = \
 	--llvm-lto 3 \
 	--llvm-opts 3 \
 	--js-opts 1 \
-	--closure 1 \
+	--closure 0 \
 	-s ENVIRONMENT=web \
 	-s MODULARIZE=1 \
 	-s AGGRESSIVE_VARIABLE_ELIMINATION=1 \
@@ -91,19 +91,19 @@ clean:
 install:
 	npm install
 
-$(BC): $(OBJS) $(FILES)
-	emcc \
+$(BC): $(FILES)
+	emcc -c \
 		$(CFLAGS) \
 		--bind \
 		$(INCLUDES) \
-		$(OBJS) \
 		$(FILES) \
 		-o $(BC)
 
-dist/wasm: $(BC)
+dist/wasm: $(OBJS) $(BC)
 	npx mkdirp dist/wasm
 	emcc \
 		$(WASM_OPTIONS) \
+		$(OBJS)
 		$(BC) \
 		-o dist/wasm/app.js
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This includes:
 
 - `asm-dom`
 - `CPX support: JSX like syntax in C++`
-- `parcel-bundler`
+- `parcel-bundler` (`npm i --save-dev parcel-bundler@1.12.3`)
 - `autoprefixer`
 
 The boilerplate automatically compiles C++ code to WebAssembly and asm.js, the client will dinamically require the first if supported, the second otherwise.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"gccx": "0.2.0",
 		"mkdirp": "0.5.1",
 		"nodemon": "1.17.4",
-		"parcel-bundler": "1.10.3",
+		"parcel-bundler": "^1.12.3",
 		"rimraf": "2.6.2"
 	},
 	"browser": {


### PR DESCRIPTION
I modified the Makefile to make the compilation work: both index.cc and asm-dom.cpp are compiled into object files separately, then they are linked together to generate the executable and app.js. closure compiler does not seem to work, so I also disabled it.

I also added a note in the README that only parcel@1.12.3 works with this repo.