### PR TITLE
Fix Makefile: correct emcc flags for latest Emscripten

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ $(BC): $(FILES)
 		$(CFLAGS) \
 		$(INCLUDES) \
 		$(FILES) \
+    -emit-llvm \
 		-o $(BC)
 
 dist/wasm: $(OBJS) $(BC)

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,6 @@ install:
 $(BC): $(FILES)
 	emcc -c \
 		$(CFLAGS) \
-		--bind \
 		$(INCLUDES) \
 		$(FILES) \
 		-o $(BC)
@@ -134,7 +133,6 @@ $(SRCDIR)/%.cc: $(SRCDIR)/%.cpp
 $(OBJDIR)/%.o: $(SRCDIR)/%.cc | $$(@D)
 	emcc \
 		$(CFLAGS) \
-		--bind \
 		$(CPPFLAGS) \
 		$(INCLUDES) \
 		-c $< \


### PR DESCRIPTION
Recent versions of emscripten (tested with 3.1.38) produce two separate fatal errors when building:

> emcc: error: linker flag ignored during compilation: '--bind' [-Wunused-command-line-argument] [-Werror]

and

> emcc: error: .bc output file suffix used without -flto or -emit-llvm.  Consider using .o extension since emcc will output an object file, not a bitcode file [-Wemcc] [-Werror]

This pull request removes the `--bind` flag from compiler options (it's a linker flag only), and adds `-emit-llvm` to the bitcode generation step.